### PR TITLE
changed import path to match filename

### DIFF
--- a/es/mixins/syncQuery.js
+++ b/es/mixins/syncQuery.js
@@ -8,7 +8,7 @@ var _vueUpdateQueryMixin = require('vue-update-query-mixin');
 
 var _vueUpdateQueryMixin2 = _interopRequireDefault(_vueUpdateQueryMixin);
 
-var _typeOf = require('../utils/typeOf');
+var _typeOf = require('../utils/typeof');
 
 var _typeOf2 = _interopRequireDefault(_typeOf);
 

--- a/src/mixins/syncQuery.js
+++ b/src/mixins/syncQuery.js
@@ -1,5 +1,5 @@
 import updateQuery from 'vue-update-query-mixin'
-import typeOf from '../utils/typeOf'
+import typeOf from '../utils/typeof'
 import mergeDesc from '../utils/mergeDesc'
 const err = msg => { throw new Error('[SyncQuery] ' + msg) }
 


### PR DESCRIPTION
`es/mixins/syncQuery.js` and `src/mixins/syncQuery.js` referenced non-existing `typeOf.js`, so it was throwing an error while importing `vue-sync-query` to Vue app. Correct file name is `typeof.js`.